### PR TITLE
タイトルの動的表示

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,6 @@
 module ApplicationHelper
+  def page_title(title = '')
+    base_title = 'どれがこむドットコム'
+    title.present? ? "#{title} | #{base_title}" : base_title
+  end
 end

--- a/app/views/blackcat_quizzes/result.html.slim
+++ b/app/views/blackcat_quizzes/result.html.slim
@@ -1,3 +1,4 @@
+= content_for(:title, '結果発表')
 .row(style="justify-content: center;")
   .col-sm-6.col-12h2.text-center
     h1 🐈結果発表🐈

--- a/app/views/blackcat_quizzes/show.html.slim
+++ b/app/views/blackcat_quizzes/show.html.slim
@@ -1,3 +1,4 @@
+= content_for(:title, "問題#{session[:question_index] + 1}")
 .row(style="justify-content: center;")
   .col-sm-6.col-12h2.text-center
     h2 style="font-size: 2em;" 🐈問題#{session[:question_index] + 1}🐈

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "どれがこむドットコム" %></title>
+    <title><%= page_title(yield(:title)) %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>


### PR DESCRIPTION
問題と結果発表の画面のタイトルを動的に表示させる
### 問題ページ
どれがこむドットコム→問題n | どれがこむドットコム
### 結果発表ページ
どれがこむドットコム→結果発表 | どれがこむドットコム